### PR TITLE
Updated menu and nav for EQW site

### DIFF
--- a/sites/equipmentworld.com/config/navigation.js
+++ b/sites/equipmentworld.com/config/navigation.js
@@ -1,18 +1,18 @@
 const topics = {
   primary: [
+    { href: '/business', label: 'Business' },
     { href: '/equipment', label: 'Equipment' },
     { href: '/better-roads', label: 'Better Roads' },
     { href: '/big-iron-dealer', label: 'Big Iron Dealer' },
-    { href: '/business', label: 'Business' },
     { href: '/technology', label: 'Technology' },
-    { href: '/workforce', label: 'Workforce' },
+    { href: '/workforce/safety', label: 'Safety' },
   ],
   expanded: [
   ],
   secondary: [
-    { href: '/workforce/safety', label: 'Safety' },
     { href: '/safety-watch', label: 'Safety Watch' },
     { href: '/white-papers', label: 'White Papers' },
+    { href: '/termsandprivacy', label: 'Terms of Use' },
   ],
 };
 
@@ -57,7 +57,7 @@ module.exports = {
   footer: {
     items: [
       { href: '/termsandprivacy', label: 'Terms of User and Privacy Policy' },
-      { href: '/collection', label: 'Point of Collection Notice' },
+      { href: 'https://www.randallreilly.com/point-of-collection-notice/', label: 'Point of Collection Notice', target: '_blank' },
       { href: 'https://privacyportal-cdn.onetrust.com/dsarwebform/49a9a972-547e-4c49-b23c-4cc77554cacb/cddab1bc-7e58-4eca-a20d-be42716734cf.html', label: 'Do Not Sell My Personal Information', target: '_blank' },
       { href: '/page/contact-us', label: 'Contact Us' },
     ],


### PR DESCRIPTION
I additionally decided the following decisions made sense (As Github Commit messages are limiting):

Safety in the navbar wanting to go to /workforce/safety

Removing the duplicate Safety entry from the menu

Making it so the Points of Collection Notice opened in a new tab as it leads to an external site (from what I understand )

![MENU+NAV](https://user-images.githubusercontent.com/46794001/111857244-38be5300-88fe-11eb-9260-67e308576ff2.png)

![MENU+NAV+CODE](https://user-images.githubusercontent.com/46794001/111857309-95217280-88fe-11eb-9b14-a6cabe533426.png)

Changes made for this commit:
https://github.com/Shinsina/randall-reilly-websites/commit/7a1cab469bce6b15da4de56c6695201a36a5bcc2
