### PR TITLE
Global email

### DIFF
--- a/packages/global/components/blocks/newsletter-signup-banner-large.marko
+++ b/packages/global/components/blocks/newsletter-signup-banner-large.marko
@@ -16,7 +16,7 @@ $ const { action, hiddenInputs, name, description } = site.getAsObject('newslett
       <input
         id="newsletter-signup-banner-large-email"
         class="form-control"
-        placeholder="example@gmail.com"
+        placeholder="blair@aol.com"
         type="email"
         name="em"
         required

--- a/packages/global/components/blocks/newsletter-signup-banner.marko
+++ b/packages/global/components/blocks/newsletter-signup-banner.marko
@@ -14,7 +14,7 @@ $ const { action, hiddenInputs, description } = site.getAsObject('newsletter.sig
         <input
           id="newsletter-signup-banner-email"
           class="form-control"
-          placeholder="example@gmail.com"
+          placeholder="blair@aol.com"
           type="email"
           name="em"
           required

--- a/packages/global/components/site-footer.marko
+++ b/packages/global/components/site-footer.marko
@@ -51,7 +51,7 @@ $ const tagline = site.get("tagline");
                     id="footer-newsletter-signup-email"
                     class="form-control"
                     type="email"
-                    placeholder="example@gmail.com"
+                    placeholder="blair@aol.com"
                     name="em"
                     required
                   />

--- a/packages/global/components/site-newsletter-menu.marko
+++ b/packages/global/components/site-newsletter-menu.marko
@@ -39,7 +39,7 @@ $ const modifiers = (!hasCookie && !fromEmail) ? ["open"] : [];
             <input
               id="newsletter-menu-email"
               class="form-control"
-              placeholder="example@gmail.com"
+              placeholder="blair@aol.com"
               type="email"
               name="em"
               required

--- a/packages/global/scss/components/_site-menu.scss
+++ b/packages/global/scss/components/_site-menu.scss
@@ -1,5 +1,5 @@
 .site-header {
-  position: static;
+  position: fixed;
   border-bottom: 1px solid $gray-400;
 }
 

--- a/sites/equipmentworld.com/config/navigation.js
+++ b/sites/equipmentworld.com/config/navigation.js
@@ -1,18 +1,18 @@
 const topics = {
   primary: [
+    { href: '/business', label: 'Business' },
     { href: '/equipment', label: 'Equipment' },
     { href: '/better-roads', label: 'Better Roads' },
     { href: '/big-iron-dealer', label: 'Big Iron Dealer' },
-    { href: '/business', label: 'Business' },
     { href: '/technology', label: 'Technology' },
-    { href: '/workforce', label: 'Workforce' },
+    { href: '/workforce/safety', label: 'Safety' },
   ],
   expanded: [
   ],
   secondary: [
-    { href: '/workforce/safety', label: 'Safety' },
     { href: '/safety-watch', label: 'Safety Watch' },
     { href: '/white-papers', label: 'White Papers' },
+    { href: '/termsandprivacy', label: 'Terms of Use' },
   ],
 };
 
@@ -57,7 +57,7 @@ module.exports = {
   footer: {
     items: [
       { href: '/termsandprivacy', label: 'Terms of User and Privacy Policy' },
-      { href: '/collection', label: 'Point of Collection Notice' },
+      { href: 'https://www.randallreilly.com/point-of-collection-notice/', label: 'Point of Collection Notice', target: '_blank' },
       { href: 'https://privacyportal-cdn.onetrust.com/dsarwebform/49a9a972-547e-4c49-b23c-4cc77554cacb/cddab1bc-7e58-4eca-a20d-be42716734cf.html', label: 'Do Not Sell My Personal Information', target: '_blank' },
       { href: '/page/contact-us', label: 'Contact Us' },
     ],


### PR DESCRIPTION
Changed the placeholder emails for all the newsletter blocks and other locations where newsletter e-mails were.

![PLACEHOLDER+EMAIL+1](https://user-images.githubusercontent.com/46794001/111857555-4e347c80-8900-11eb-97a9-758f68974343.png)

![PLACEHOLDER+EMAIL+2](https://user-images.githubusercontent.com/46794001/111857558-52f93080-8900-11eb-86a1-4ab2045ff21a.png)

Changes for this were accidentally made in two different commits:
https://github.com/Shinsina/randall-reilly-websites/commit/26bc60f22acaf6832335fa6fc9f553a098442b86
https://github.com/Shinsina/randall-reilly-websites/commit/98081261e91c4323efe3e326d1a801b5d3cf1e97